### PR TITLE
Allow to be the "SSO relay" for two different domains

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding:utf-8 -*-
-
-
 from saml2 import (
     BINDING_HTTP_POST,
     BINDING_HTTP_REDIRECT,
@@ -49,6 +45,12 @@ def _default_next_url():
 
 
 def get_current_domain(r):
+    if 'SECONDARY' in settings.SAML2_AUTH:
+        next_url = r.session.get(
+            'login_next_url', r.POST.get('RelayState', '')
+        )
+        if settings.SAML2_AUTH['SECONDARY']['SITE'] in next_url:
+            return settings.SAML2_AUTH['SECONDARY']['ASSERTION_URL']
     if 'ASSERTION_URL' in settings.SAML2_AUTH:
         return settings.SAML2_AUTH['ASSERTION_URL']
     return '{scheme}://{host}'.format(
@@ -89,7 +91,8 @@ def _get_metadata():
         }
 
 
-def _get_saml_client(domain):
+def _get_saml_client(r):
+    domain = get_current_domain(r)
     acs_url = domain + get_reverse([acs, 'acs', 'django_saml2_auth:acs'])
     metadata = _get_metadata()
 
@@ -112,7 +115,15 @@ def _get_saml_client(domain):
         },
     }
 
-    if 'ENTITY_ID' in settings.SAML2_AUTH:
+    if 'SECONDARY' in settings.SAML2_AUTH:
+        next_url = r.session.get(
+            'login_next_url', r.POST.get('RelayState', '')
+        )
+        if settings.SAML2_AUTH['SECONDARY']['SITE'] in next_url:
+            saml_settings['entityid'] = settings.SAML2_AUTH['SECONDARY']['ENTITY_ID']
+        else:
+            saml_settings['entityid'] = settings.SAML2_AUTH['ENTITY_ID']
+    elif 'ENTITY_ID' in settings.SAML2_AUTH:
         saml_settings['entityid'] = settings.SAML2_AUTH['ENTITY_ID']
 
     if 'NAME_ID_FORMAT' in settings.SAML2_AUTH:
@@ -155,7 +166,7 @@ def _create_new_user(username, email, firstname, lastname):
 
 @csrf_exempt
 def acs(r):
-    saml_client = _get_saml_client(get_current_domain(r))
+    saml_client = _get_saml_client(r)
     resp = r.POST.get('SAMLResponse', None)
     next_url = r.session.get('login_next_url', _default_next_url())
     # If relayState params is passed, use that else consider the previous 'next_url'
@@ -248,7 +259,7 @@ def signin(r):
 
     r.session['login_next_url'] = next_url
 
-    saml_client = _get_saml_client(get_current_domain(r))
+    saml_client = _get_saml_client(r)
     _, info = saml_client.prepare_for_authenticate(relay_state=next_url)
 
     redirect_url = None


### PR DESCRIPTION
The idea is to keep this branch alive for a while (as long as we need to support two different sites), as changes cover only our use case (based on assertion url and entity id), and are only documented in client project